### PR TITLE
Add sensor that shows configured actions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
         additional_dependencies:
           - pytest-homeassistant-custom-component==0.2.1
           - homeassistant
-          - motioneye-client==0.3.6
+          - motioneye-client==0.3.7
         verbose: true
         args:
           - --strict

--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ Home Assistant > Configuration > Integrations > motionEye > Options
 
 ### Entities
 
-| Platform | Description                                                                                                               |
-| -------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `camera` | An MJPEG camera that shows the motionEye video stream.                                                                    |
-| `switch` | Switch entities to enable/disable motion detection, text overlay, video streaming, still image capture and movie capture. |
+| Platform | Description                                                                                                                                                                                                                                   |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `camera` | An MJPEG camera that shows the motionEye video stream.                                                                                                                                                                                        |
+| `switch` | Switch entities to enable/disable motion detection, text overlay, video streaming, still image capture and movie capture.                                                                                                                     |
+| `sensor` | An "action sensor" that shows the number of configured [actions](https://github.com/ccrisan/motioneye/wiki/Action-Buttons) for this device. The names of the available actions are viewable in the `actions`  attribute of the sensor entity. |
 
 Notes:
    * If the video streaming switch is turned off, the camera entity will become unavailable (but the rest of the integration will continue to work).

--- a/custom_components/motioneye/__init__.py
+++ b/custom_components/motioneye/__init__.py
@@ -39,6 +39,7 @@ import voluptuous as vol
 
 from homeassistant.components.camera.const import DOMAIN as CAMERA_DOMAIN
 from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntry
 from homeassistant.const import (
@@ -96,7 +97,7 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-PLATFORMS = [CAMERA_DOMAIN, SWITCH_DOMAIN]
+PLATFORMS = [CAMERA_DOMAIN, SENSOR_DOMAIN, SWITCH_DOMAIN]
 
 
 def create_motioneye_client(

--- a/custom_components/motioneye/const.py
+++ b/custom_components/motioneye/const.py
@@ -97,8 +97,9 @@ SERVICE_SNAPSHOT = "snapshot"
 SIGNAL_CAMERA_ADD = f"{DOMAIN}_camera_add_signal." "{}"
 SIGNAL_CAMERA_REMOVE = f"{DOMAIN}_camera_remove_signal." "{}"
 
-TYPE_MOTIONEYE_MJPEG_CAMERA = "motioneye_mjpeg_camera"
-TYPE_MOTIONEYE_SWITCH_BASE = "motioneye_switch"
+TYPE_MOTIONEYE_MJPEG_CAMERA = f"{DOMAIN}_mjpeg_camera"
+TYPE_MOTIONEYE_SWITCH_BASE = f"{DOMAIN}_switch"
+TYPE_MOTIONEYE_ACTION_SENSOR = f"{DOMAIN}_action_sensor"
 
 WEB_HOOK_SENTINEL_KEY = "src"
 WEB_HOOK_SENTINEL_VALUE = "hass-motioneye"

--- a/custom_components/motioneye/manifest.json
+++ b/custom_components/motioneye/manifest.json
@@ -6,7 +6,7 @@
   "config_flow": true,
   "dependencies": ["http", "media_source"],
   "requirements": [
-    "motioneye-client==0.3.6"
+    "motioneye-client==0.3.7"
   ],
   "codeowners": [
     "@dermotduffy"

--- a/custom_components/motioneye/sensor.py
+++ b/custom_components/motioneye/sensor.py
@@ -1,0 +1,106 @@
+"""The motionEye integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+from motioneye_client.client import MotionEyeClient
+from motioneye_client.const import KEY_ACTIONS, KEY_ID, KEY_NAME
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from . import (
+    get_camera_from_cameras,
+    get_motioneye_device_identifier,
+    get_motioneye_entity_unique_id,
+    listen_for_new_cameras,
+)
+from .const import CONF_CLIENT, CONF_COORDINATOR, DOMAIN, TYPE_MOTIONEYE_ACTION_SENSOR
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS = ["camera"]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: Callable
+) -> None:
+    """Set up motionEye from a config entry."""
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+
+    @callback  # type: ignore[misc]
+    def camera_add(camera: dict[str, Any]) -> None:
+        """Add a new motionEye camera."""
+        async_add_entities(
+            [
+                MotionEyeActionSensor(
+                    entry.entry_id,
+                    camera,
+                    entry_data[CONF_CLIENT],
+                    entry_data[CONF_COORDINATOR],
+                )
+            ]
+        )
+
+    listen_for_new_cameras(hass, entry, camera_add)
+
+
+class MotionEyeActionSensor(CoordinatorEntity, SensorEntity):  # type: ignore[misc]
+    """motionEye action sensor camera."""
+
+    def __init__(
+        self,
+        config_entry_id: str,
+        camera: dict[str, Any],
+        client: MotionEyeClient,
+        coordinator: DataUpdateCoordinator,
+    ) -> None:
+        """Initialize an action sensor."""
+        self._camera_id = camera[KEY_ID]
+        self._device_identifier = get_motioneye_device_identifier(
+            config_entry_id, self._camera_id
+        )
+        self._unique_id = get_motioneye_entity_unique_id(
+            config_entry_id, self._camera_id, TYPE_MOTIONEYE_ACTION_SENSOR
+        )
+        self._client = client
+        self._camera: dict[str, Any] | None = camera
+        super().__init__(coordinator)
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique id."""
+        return self._unique_id
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        camera_name = self._camera[KEY_NAME] if self._camera else ""
+        return f"{camera_name} Actions"
+
+    @property
+    def state(self) -> int:
+        """Return the state of the sensor."""
+        return len(self._camera.get(KEY_ACTIONS, [])) if self._camera else 0
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return the device information."""
+        return {"identifiers": {self._device_identifier}}
+
+    @callback  # type: ignore[misc]
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._camera = get_camera_from_cameras(self._camera_id, self.coordinator.data)
+        super()._handle_coordinator_update()
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Whether or not the entity is enabled by default."""
+        return False

--- a/custom_components/motioneye/sensor.py
+++ b/custom_components/motioneye/sensor.py
@@ -90,6 +90,11 @@ class MotionEyeActionSensor(CoordinatorEntity, SensorEntity):  # type: ignore[mi
         return len(self._camera.get(KEY_ACTIONS, [])) if self._camera else 0
 
     @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Add actions as attribute."""
+        return {KEY_ACTIONS: self._camera.get(KEY_ACTIONS, []) if self._camera else []}
+
+    @property
     def device_info(self) -> dict[str, Any]:
         """Return the device information."""
         return {"identifiers": {self._device_identifier}}

--- a/custom_components/motioneye/switch.py
+++ b/custom_components/motioneye/switch.py
@@ -141,4 +141,4 @@ class MotionEyeSwitch(SwitchEntity, CoordinatorEntity):  # type: ignore[misc]
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._camera = get_camera_from_cameras(self._camera_id, self.coordinator.data)
-        CoordinatorEntity._handle_coordinator_update(self)
+        super()._handle_coordinator_update()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 homeassistant
 aiohttp_cors
-motioneye-client==0.3.6
+motioneye-client==0.3.7

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -305,7 +305,8 @@ async def test_device_info(hass: HomeAssistant) -> None:
     device = device_registry.async_get_device({device_identifier})
     assert device
 
-    # Test device details here (not tested for other platforms).
+    # Test device details here (not tested for other platforms as the are set
+    # centrally).
     assert device.config_entries == {TEST_CONFIG_ENTRY_ID}
     assert device.identifiers == {device_identifier}
     assert device.manufacturer == MOTIONEYE_MANUFACTURER

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -297,14 +297,15 @@ async def test_state_attributes(hass: HomeAssistant) -> None:
 
 async def test_device_info(hass: HomeAssistant) -> None:
     """Verify device information includes expected details."""
-    client = create_mock_motioneye_client()
-    entry = await setup_mock_motioneye_config_entry(hass, client=client)
+    entry = await setup_mock_motioneye_config_entry(hass)
 
     device_identifier = get_motioneye_device_identifier(entry.entry_id, TEST_CAMERA_ID)
     device_registry = dr.async_get(hass)
 
     device = device_registry.async_get_device({device_identifier})
     assert device
+
+    # Test device details here (not tested for other platforms).
     assert device.config_entries == {TEST_CONFIG_ENTRY_ID}
     assert device.identifiers == {device_identifier}
     assert device.manufacturer == MOTIONEYE_MANUFACTURER

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -43,6 +43,7 @@ async def test_sensor_actions(hass: HomeAssistant) -> None:
     entity_state = hass.states.get(TEST_SENSOR_ACTION_ENTITY_ID)
     assert entity_state
     assert entity_state.state == "3"
+    assert entity_state.attributes.get(KEY_ACTIONS) == ["one", "two", "three"]
 
     updated_camera = copy.deepcopy(TEST_CAMERA)
     updated_camera[KEY_ACTIONS] = ["one"]
@@ -55,6 +56,7 @@ async def test_sensor_actions(hass: HomeAssistant) -> None:
     entity_state = hass.states.get(TEST_SENSOR_ACTION_ENTITY_ID)
     assert entity_state
     assert entity_state.state == "1"
+    assert entity_state.attributes.get(KEY_ACTIONS) == ["one"]
 
     del updated_camera[KEY_ACTIONS]
     async_fire_time_changed(hass, dt_util.utcnow() + DEFAULT_SCAN_INTERVAL)
@@ -63,6 +65,7 @@ async def test_sensor_actions(hass: HomeAssistant) -> None:
     entity_state = hass.states.get(TEST_SENSOR_ACTION_ENTITY_ID)
     assert entity_state
     assert entity_state.state == "0"
+    assert entity_state.attributes.get(KEY_ACTIONS) == []
 
 
 async def test_sensor_device_info(hass: HomeAssistant) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,128 @@
+"""Tests for the motionEye switch platform."""
+import copy
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+from motioneye_client.const import KEY_ACTIONS
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+
+from custom_components.motioneye import get_motioneye_device_identifier
+from custom_components.motioneye.const import (
+    DEFAULT_SCAN_INTERVAL,
+    TYPE_MOTIONEYE_ACTION_SENSOR,
+)
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+import homeassistant.util.dt as dt_util
+
+from . import (
+    TEST_CAMERA,
+    TEST_CAMERA_ID,
+    TEST_SENSOR_ACTION_ENTITY_ID,
+    create_mock_motioneye_client,
+    register_test_entity,
+    setup_mock_motioneye_config_entry,
+)
+
+
+async def test_sensor_actions(hass: HomeAssistant) -> None:
+    """Test the actions sensor."""
+    register_test_entity(
+        hass,
+        SENSOR_DOMAIN,
+        TEST_CAMERA_ID,
+        TYPE_MOTIONEYE_ACTION_SENSOR,
+        TEST_SENSOR_ACTION_ENTITY_ID,
+    )
+
+    client = create_mock_motioneye_client()
+    await setup_mock_motioneye_config_entry(hass, client=client)
+
+    entity_state = hass.states.get(TEST_SENSOR_ACTION_ENTITY_ID)
+    assert entity_state
+    assert entity_state.state == "3"
+
+    updated_camera = copy.deepcopy(TEST_CAMERA)
+    updated_camera[KEY_ACTIONS] = ["one"]
+
+    # When the next refresh is called return the updated values.
+    client.async_get_cameras = AsyncMock(return_value={"cameras": [updated_camera]})
+    async_fire_time_changed(hass, dt_util.utcnow() + DEFAULT_SCAN_INTERVAL)
+    await hass.async_block_till_done()
+
+    entity_state = hass.states.get(TEST_SENSOR_ACTION_ENTITY_ID)
+    assert entity_state
+    assert entity_state.state == "1"
+
+    del updated_camera[KEY_ACTIONS]
+    async_fire_time_changed(hass, dt_util.utcnow() + DEFAULT_SCAN_INTERVAL)
+    await hass.async_block_till_done()
+
+    entity_state = hass.states.get(TEST_SENSOR_ACTION_ENTITY_ID)
+    assert entity_state
+    assert entity_state.state == "0"
+
+
+async def test_sensor_device_info(hass: HomeAssistant) -> None:
+    """Verify device information includes expected details."""
+
+    # Enable the action sensor (it is disabled by default).
+    register_test_entity(
+        hass,
+        SENSOR_DOMAIN,
+        TEST_CAMERA_ID,
+        TYPE_MOTIONEYE_ACTION_SENSOR,
+        TEST_SENSOR_ACTION_ENTITY_ID,
+    )
+
+    config_entry = await setup_mock_motioneye_config_entry(hass)
+
+    device_identifer = get_motioneye_device_identifier(
+        config_entry.entry_id, TEST_CAMERA_ID
+    )
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device({device_identifer})
+    assert device
+
+    entity_registry = await er.async_get_registry(hass)
+    entities_from_device = [
+        entry.entity_id
+        for entry in er.async_entries_for_device(entity_registry, device.id)
+    ]
+    assert TEST_SENSOR_ACTION_ENTITY_ID in entities_from_device
+
+
+async def test_sensor_actions_can_be_enabled(hass: HomeAssistant) -> None:
+    """Verify the action sensor can be enabled."""
+    client = create_mock_motioneye_client()
+    await setup_mock_motioneye_config_entry(hass, client=client)
+    entity_registry = er.async_get(hass)
+
+    entry = entity_registry.async_get(TEST_SENSOR_ACTION_ENTITY_ID)
+    assert entry
+    assert entry.disabled
+    assert entry.disabled_by == er.DISABLED_INTEGRATION
+    entity_state = hass.states.get(TEST_SENSOR_ACTION_ENTITY_ID)
+    assert not entity_state
+
+    with patch(
+        "custom_components.motioneye.MotionEyeClient",
+        return_value=client,
+    ):
+        updated_entry = entity_registry.async_update_entity(
+            TEST_SENSOR_ACTION_ENTITY_ID, disabled_by=None
+        )
+        assert not updated_entry.disabled
+        await hass.async_block_till_done()
+
+        async_fire_time_changed(
+            hass,
+            dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+        )
+        await hass.async_block_till_done()
+
+    entity_state = hass.states.get(TEST_SENSOR_ACTION_ENTITY_ID)
+    assert entity_state

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -13,10 +13,7 @@ from motioneye_client.const import (
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
 from custom_components.motioneye import get_motioneye_device_identifier
-from custom_components.motioneye.const import (
-    DEFAULT_SCAN_INTERVAL,
-    MOTIONEYE_MANUFACTURER,
-)
+from custom_components.motioneye.const import DEFAULT_SCAN_INTERVAL
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
@@ -26,8 +23,6 @@ import homeassistant.util.dt as dt_util
 from . import (
     TEST_CAMERA,
     TEST_CAMERA_ID,
-    TEST_CAMERA_NAME,
-    TEST_CONFIG_ENTRY_ID,
     TEST_SWITCH_ENTITY_ID_BASE,
     TEST_SWITCH_MOTION_DETECTION_ENTITY_ID,
     create_mock_motioneye_client,
@@ -117,8 +112,7 @@ async def test_switch_has_correct_entities(hass: HomeAssistant) -> None:
 
 async def test_switch_device_info(hass: HomeAssistant) -> None:
     """Verify device information includes expected details."""
-    client = create_mock_motioneye_client()
-    config_entry = await setup_mock_motioneye_config_entry(hass, client=client)
+    config_entry = await setup_mock_motioneye_config_entry(hass)
 
     device_identifer = get_motioneye_device_identifier(
         config_entry.entry_id, TEST_CAMERA_ID
@@ -127,11 +121,6 @@ async def test_switch_device_info(hass: HomeAssistant) -> None:
 
     device = device_registry.async_get_device({device_identifer})
     assert device
-    assert device.config_entries == {TEST_CONFIG_ENTRY_ID}
-    assert device.identifiers == {device_identifer}
-    assert device.manufacturer == MOTIONEYE_MANUFACTURER
-    assert device.model == MOTIONEYE_MANUFACTURER
-    assert device.name == TEST_CAMERA_NAME
 
     entity_registry = await er.async_get_registry(hass)
     entities_from_device = [


### PR DESCRIPTION
Add a sensor that shows the number of configured  actions per motionEye device, with the action names as an attribute.